### PR TITLE
Fix ModMenu Version for 1.19 (update to 4.0.0)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ archives_base_name = keymap
 # Dependencies
 fabric_version=0.57.0+1.19
 version_cloth_api=7.0.72
-version_mod_menu=3.2.3
+version_mod_menu=4.0.0
 version_malilib=1.19-0.12.1
 
 # malilib testing


### PR DESCRIPTION
The referenced Mod Menu version was wrong and doesn't even exist for 1.19. 4.0.0 is the correct version of mod menu for 1.19.