### PR TITLE
Add japanese key layout (109-key)

### DIFF
--- a/common/src/main/java/com/github/einjerjar/mc/keymap/keys/layout/KeyLayout.java
+++ b/common/src/main/java/com/github/einjerjar/mc/keymap/keys/layout/KeyLayout.java
@@ -120,7 +120,7 @@ public class KeyLayout {
                 // simple notice, since sonarlint/intellij is complaining about readability
                 // ----------------- another try-catch block starts here -----------------
                 try (InputStreamReader reader =
-                             new InputStreamReader(Objects.requireNonNull(loader.getResourceAsStream(LAYOUT_ROOT + p.getFileName())))) {
+                             new InputStreamReader(Objects.requireNonNull(loader.getResourceAsStream(LAYOUT_ROOT + p.getFileName())), "UTF-8")) {
                     registerLayout(gson.fromJson(reader, KeyLayout.class));
                 } catch (Exception e) {
                     Keymap.logger().warn("Can't load {} ; {}", p.getFileName(), e.getMessage());

--- a/common/src/main/resources/assets/keymap/layouts/ja_jp.json
+++ b/common/src/main/resources/assets/keymap/layouts/ja_jp.json
@@ -1,0 +1,567 @@
+{
+    "meta": {
+        "name": "Japanese",
+        "code": "ja_jp"
+    },
+    "keys": {
+        "basic": [
+            {
+                "row": [
+                    {
+                        "code": 256,
+                        "name": "ESC",
+                        "width": 14
+                    },
+                    {
+                        "name": "F1",
+                        "code": 290,
+                        "width": 2
+                    },
+                    {
+                        "name": "F2",
+                        "code": 291,
+                        "width": 2
+                    },
+                    {
+                        "name": "F3",
+                        "code": 292,
+                        "width": 2
+                    },
+                    {
+                        "name": "F4",
+                        "code": 293,
+                        "width": 2
+                    },
+                    {
+                        "name": "F5",
+                        "code": 294,
+                        "width": 2
+                    },
+                    {
+                        "name": "F6",
+                        "code": 295,
+                        "width": 2
+                    },
+                    {
+                        "name": "F7",
+                        "code": 296,
+                        "width": 2
+                    },
+                    {
+                        "name": "F8",
+                        "code": 297,
+                        "width": 2
+                    },
+                    {
+                        "name": "F9",
+                        "code": 298,
+                        "width": 2
+                    },
+                    {
+                        "name": "F10",
+                        "code": 299,
+                        "width": 2
+                    },
+                    {
+                        "name": "F11",
+                        "code": 300,
+                        "width": 2
+                    },
+                    {
+                        "name": "F12",
+                        "code": 301,
+                        "width": 2
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "`",
+                        "code": 96
+                    },
+                    {
+                        "name": "1",
+                        "code": 49
+                    },
+                    {
+                        "name": "2",
+                        "code": 50
+                    },
+                    {
+                        "name": "3",
+                        "code": 51
+                    },
+                    {
+                        "name": "4",
+                        "code": 52
+                    },
+                    {
+                        "name": "5",
+                        "code": 53
+                    },
+                    {
+                        "name": "6",
+                        "code": 54
+                    },
+                    {
+                        "name": "7",
+                        "code": 55
+                    },
+                    {
+                        "name": "8",
+                        "code": 56
+                    },
+                    {
+                        "name": "9",
+                        "code": 57
+                    },
+                    {
+                        "name": "0",
+                        "code": 48
+                    },
+                    {
+                        "name": "-",
+                        "code": 45
+                    },
+                    {
+                        "name": "^",
+                        "code": 61
+                    },
+                    {
+                        "name": "¥",
+                        "code": 125
+                    },
+                    {
+                        "name": "BKS",
+                        "code": 259,
+                        "width": 2
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "TAB",
+                        "code": 258,
+                        "width": 10
+                    },
+                    {
+                        "name": "Q",
+                        "code": 81
+                    },
+                    {
+                        "name": "W",
+                        "code": 87
+                    },
+                    {
+                        "name": "E",
+                        "code": 69
+                    },
+                    {
+                        "name": "R",
+                        "code": 82
+                    },
+                    {
+                        "name": "T",
+                        "code": 84
+                    },
+                    {
+                        "name": "Y",
+                        "code": 89
+                    },
+                    {
+                        "name": "U",
+                        "code": 85
+                    },
+                    {
+                        "name": "I",
+                        "code": 73
+                    },
+                    {
+                        "name": "O",
+                        "code": 79
+                    },
+                    {
+                        "name": "P",
+                        "code": 80
+                    },
+                    {
+                        "name": "@",
+                        "code": 91
+                    },
+                    {
+                        "name": "[",
+                        "code": 93
+                    },
+                    {
+                        "name": "ENT",
+                        "code": 257,
+                        "width": 10
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "CAPS",
+                        "code": 280,
+                        "width": 16
+                    },
+                    {
+                        "name": "A",
+                        "code": 65
+                    },
+                    {
+                        "name": "S",
+                        "code": 83
+                    },
+                    {
+                        "name": "D",
+                        "code": 68
+                    },
+                    {
+                        "name": "F",
+                        "code": 70
+                    },
+                    {
+                        "name": "G",
+                        "code": 71
+                    },
+                    {
+                        "name": "H",
+                        "code": 72
+                    },
+                    {
+                        "name": "J",
+                        "code": 74
+                    },
+                    {
+                        "name": "K",
+                        "code": 75
+                    },
+                    {
+                        "name": "L",
+                        "code": 76
+                    },
+                    {
+                        "name": ";",
+                        "code": 59
+                    },
+                    {
+                        "name": ":",
+                        "code": 39
+                    },
+                    {
+                        "name": "]",
+                        "code": 92
+                    },
+                    {
+                        "name": "ENT",
+                        "code": 257,
+                        "width": 4
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "LSH",
+                        "code": 340,
+                        "width": 24
+                    },
+                    {
+                        "name": "Z",
+                        "code": 90
+                    },
+                    {
+                        "name": "X",
+                        "code": 88
+                    },
+                    {
+                        "name": "C",
+                        "code": 67
+                    },
+                    {
+                        "name": "V",
+                        "code": 86
+                    },
+                    {
+                        "name": "B",
+                        "code": 66
+                    },
+                    {
+                        "name": "N",
+                        "code": 78
+                    },
+                    {
+                        "name": "M",
+                        "code": 77
+                    },
+                    {
+                        "name": ",",
+                        "code": 44
+                    },
+                    {
+                        "name": ".",
+                        "code": 46
+                    },
+                    {
+                        "name": "/",
+                        "code": 47
+                    },
+                    {
+                        "name": "\\",
+                        "code": 115
+                    },
+                    {
+                        "name": "RSH",
+                        "code": 344,
+                        "width": 14
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "LCL",
+                        "code": 341,
+                        "width": 6
+                    },
+                    {
+                        "name": "LWN",
+                        "code": 343,
+                        "width": 6
+                    },
+                    {
+                        "name": "LAL",
+                        "code": 342,
+                        "width": 6
+                    },
+                    {
+                    	"name": "無",
+                    	"code": 123
+                    },
+                    {
+                        "name": "SPACE",
+                        "code": 32,
+                        "width": 28,
+                        "height": 0
+                    },
+                    {
+                    	"name": "変",
+                    	"code": 121
+                    },
+                    {
+                    	"name": "かな",
+                    	"code": 112,
+                    	"width": 4
+                    },
+                    {
+                        "name": "RAL",
+                        "code": 346,
+                        "width": 6
+                    },
+                    {
+                        "name": "RWN",
+                        "code": 347,
+                        "width": 6
+                    },
+                    {
+                        "name": "MNU",
+                        "code": 348,
+                        "width": 6
+                    },
+                    {
+                        "name": "RCL",
+                        "code": 345,
+                        "width": 6
+                    }
+                ]
+            }
+        ],
+        "extra": [
+            {
+                "row": [
+                    {
+                        "name": "INS",
+                        "code": 260,
+                        "width": 6
+                    },
+                    {
+                        "name": "HME",
+                        "code": 268,
+                        "width": 6
+                    },
+                    {
+                        "name": "PGU",
+                        "code": 266,
+                        "width": 6
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "DEL",
+                        "code": 261,
+                        "width": 6
+                    },
+                    {
+                        "name": "END",
+                        "code": 269,
+                        "width": 6
+                    },
+                    {
+                        "name": "PGD",
+                        "code": 267,
+                        "width": 6
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "<",
+                        "code": 263
+                    },
+                    {
+                        "name": "^",
+                        "code": 265
+                    },
+                    {
+                        "name": "V",
+                        "code": 264
+                    },
+                    {
+                        "name": ">",
+                        "code": 262
+                    }
+                ]
+            }
+        ],
+        "mouse": [
+            {
+                "row": [
+                    {
+                        "name": "ML",
+                        "code": 0,
+                        "width": 6
+                    },
+                    {
+                        "name": "MM",
+                        "code": 2,
+                        "width": 6
+                    },
+                    {
+                        "name": "MR",
+                        "code": 1,
+                        "width": 6
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "Other Mouse",
+                        "code": -2,
+                        "width": 54
+                    }
+                ]
+            }
+        ],
+        "numpad": [
+            {
+                "row": [
+                    {
+                        "name": "NM",
+                        "code": 282
+                    },
+                    {
+                        "name": "/",
+                        "code": 331
+                    },
+                    {
+                        "name": "*",
+                        "code": 332
+                    },
+                    {
+                        "name": "-",
+                        "code": 333
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "7",
+                        "code": 327
+                    },
+                    {
+                        "name": "8",
+                        "code": 328
+                    },
+                    {
+                        "name": "9",
+                        "code": 329
+                    },
+                    {
+                        "name": "+",
+                        "code": 334,
+                        "height": 18
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "4",
+                        "code": 324
+                    },
+                    {
+                        "name": "5",
+                        "code": 325
+                    },
+                    {
+                        "name": "6",
+                        "code": 326
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "1",
+                        "code": 321
+                    },
+                    {
+                        "name": "2",
+                        "code": 322
+                    },
+                    {
+                        "name": "3",
+                        "code": 323
+                    },
+                    {
+                        "name": "EN",
+                        "code": 335,
+                        "height": 18
+                    }
+                ]
+            },
+            {
+                "row": [
+                    {
+                        "name": "0",
+                        "code": 320,
+                        "width": 18
+                    },
+                    {
+                        "name": ".",
+                        "code": 330
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
109-key layout added.
This is the keyboard layout commonly used in Japan.
![2022-08-26_10 52 27](https://user-images.githubusercontent.com/48321445/186805946-e7a9777b-8ee3-459b-b4b6-13ce2d4d543d.png)

In addition, garbled characters were observed in Japanese environment, which has been corrected.
![2022-08-26_10 48 16](https://user-images.githubusercontent.com/48321445/186806798-d48f3065-f83d-4191-9362-70537a2b0553.png)
(Image before being fixed.)